### PR TITLE
Add `search` and `task` labels

### DIFF
--- a/labels/commons.json
+++ b/labels/commons.json
@@ -121,6 +121,11 @@
     "description": "Issues related to refunds."
   },
   {
+    "name": "component: search",
+    "color": "ffea00",
+    "description": "Issues related to search."
+  },
+  {
     "name": "component: shipping",
     "color": "ffea00",
     "description": "Issues related to shipping."
@@ -307,6 +312,11 @@
     "name": "status: testing instructions added",
     "color": "2fc45e",
     "description": "PRs that has had testing instructions added to the wiki."
+  },
+  {
+    "name": "task",
+    "color": "00ee00",
+    "description": "To-Do item for WooCommerce Core team."
   },
   {
     "name": "templating",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-github-sync-labels",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR adds 2 new GH labels:

- `task` - To-Do item for WooCommerce Core team
- `component: search` - Issues related to search