### PR TITLE
Add Action Scheduler repository and `regression` label

### DIFF
--- a/labels/commons.json
+++ b/labels/commons.json
@@ -315,6 +315,11 @@
     "description": "Code needs refactoring."
   },
   {
+    "name": "regression",
+    "color": "ff195f",
+    "description": "Issues that have been introduced by the code change that impacted existing functionality."
+  },
+  {
     "name": "status: approved",
     "color": "0e8a16",
     "description": "PRs that have been approved and ready to be merged.",

--- a/labels/commons.json
+++ b/labels/commons.json
@@ -71,6 +71,14 @@
     "description": "Issues related to CSV import and export."
   },
   {
+    "name": "component: data-store",
+    "color": "ffea00",
+    "description": "Issues related to custom tables.",
+    "aliases": [
+      "type: custom-tables"
+    ]
+  },
+  {
     "name": "component: email",
     "color": "ffea00",
     "description": "Issues related to emails."
@@ -166,9 +174,25 @@
     "description": "Issues related to WooCommerce CLI."
   },
   {
+    "name": "component: wp-cli",
+    "color": "ffea00",
+    "description": "Issues related to WordPress CLI.",
+    "aliases": [
+      "WP CLI"
+    ]
+  },
+  {
     "name": "design",
     "color": "dd7a97",
     "description": "Needs design feedback. [auto]"
+  },
+  {
+    "name": "duplicate",
+    "color": "abd99d",
+    "description": "Issues that have already been filed.",
+    "aliases": [
+      "duplicate"
+    ]
   },
   {
     "name": "E2E",
@@ -209,7 +233,8 @@
     "color": "1d76db",
     "description": "Issue that has pull request.",
     "aliases": [
-      "status: has pull request"
+      "status: has pull request",
+      "hasPR"
     ]
   },
   {
@@ -240,7 +265,10 @@
   {
     "name": "performance",
     "color": "fef2c0",
-    "description": "Issues related to performance (code / DB / web performance)."
+    "description": "Issues related to performance (code / DB / web performance).",
+    "aliases": [
+      "performance"
+    ]
   },
   {
     "name": "priority: critical",
@@ -250,12 +278,18 @@
   {
     "name": "priority: high",
     "color": "7f54b3",
-    "description": "Important, but no one will go out of business."
+    "description": "Important, but no one will go out of business.",
+    "aliases": [
+      "priority:high"
+    ]
   },
   {
     "name": "priority: low",
     "color": "af7dd1",
-    "description": "Nice-to-haves and niche cases."
+    "description": "Nice-to-haves and niche cases.",
+    "aliases": [
+      "priority:low"
+    ]
   },
   {
     "name": "privacy",
@@ -291,7 +325,10 @@
   {
     "name": "status: blocked",
     "color": "b60205",
-    "description": "Issue or PR is blocked by external factor."
+    "description": "Issue or PR is blocked by external factor.",
+    "aliases": [
+      "status: blocked"
+    ]
   },
   {
     "name": "status: changelog added",
@@ -299,9 +336,20 @@
     "description": "Mark all PRs that have their changelog entries added to readme.txt"
   },
   {
+    "name": "status: has feedback",
+    "color": "307121",
+    "description": "Issues for which we requested feedback from the author and received it.",
+    "aliases": [
+      "Status: Has Feedback"
+    ]
+  },
+  {
     "name": "status: in progress",
     "color": "f5f5f5",
-    "description": "This is being worked on."
+    "description": "This is being worked on.",
+    "aliases": [
+      "Status: Work in Progress"
+    ]
   },
   {
     "name": "status: needs changelog",
@@ -311,17 +359,26 @@
   {
     "name": "status: needs docs",
     "color": "9cfcda",
-    "description": "Needs explanation in release notes, dev blog, or documentation."
+    "description": "Needs explanation in release notes, dev blog, or documentation.",
+    "aliases": [
+      "status: Docs"
+    ]
   },
   {
     "name": "status: needs feedback",
     "color": "f5f5f5",
-    "description": "Needs feedback from the author/developers."
+    "description": "Needs feedback from the author/developers.",
+    "aliases": [
+      "status: needs feedback"
+    ]
   },
   {
     "name": "status: needs review",
     "color": "1d76db",
-    "description": "PR that needs review. [auto]"
+    "description": "PR that needs review. [auto]",
+    "aliases": [
+      "Status: Needs Review"
+    ]
   },
   {
     "name": "status: needs testing instructions",
@@ -336,7 +393,10 @@
   {
     "name": "task",
     "color": "00ee00",
-    "description": "To-Do item for WooCommerce Core team."
+    "description": "To-Do item for WooCommerce Core team.",
+    "aliases": [
+      "todo 🗒️"
+    ]
   },
   {
     "name": "templating",
@@ -356,7 +416,10 @@
   {
     "name": "won't fix",
     "color": "f5f5f5",
-    "description": "Issue that will not be fixed at this time."
+    "description": "Issue that will not be fixed at this time.",
+    "aliases": [
+      "wontfix"
+    ]
   },
   {
     "name": "wordpress",

--- a/labels/commons.json
+++ b/labels/commons.json
@@ -324,6 +324,7 @@
     "color": "0e8a16",
     "description": "PRs that have been approved and ready to be merged.",
     "aliases": [
+      "Status: Needs Merge",
       "status: ready to merge"
     ]
   },
@@ -366,7 +367,8 @@
     "color": "9cfcda",
     "description": "Needs explanation in release notes, dev blog, or documentation.",
     "aliases": [
-      "status: Docs"
+      "status: Docs",
+      "question"
     ]
   },
   {
@@ -374,6 +376,7 @@
     "color": "f5f5f5",
     "description": "Needs feedback from the author/developers.",
     "aliases": [
+      "bug:needs-confirmation",
       "status: needs feedback"
     ]
   },
@@ -400,6 +403,7 @@
     "color": "00ee00",
     "description": "To-Do item for WooCommerce Core team.",
     "aliases": [
+      "Housekeeping",
       "todo 🗒️"
     ]
   },
@@ -407,6 +411,11 @@
     "name": "templating",
     "color": "fef2c0",
     "description": "Issue related to WooCommerce templates."
+  },
+  {
+    "name": "unit test",
+    "color": "ee7b30",
+    "description": "Issue related to unit tests or PRs that contain the changes for which unit tests need to be added."
   },
   {
     "name": "votes needed",

--- a/labels/commons.json
+++ b/labels/commons.json
@@ -399,6 +399,14 @@
     "description": "PRs that has had testing instructions added to the wiki."
   },
   {
+    "name": "status: needs unit test",
+    "color": "ee7b30",
+    "description": "PRs that contain the changes for which unit tests need to be added.",
+    "aliases": [
+      "Unit Tests"
+    ]
+  },
+  {
     "name": "task",
     "color": "00ee00",
     "description": "To-Do item for WooCommerce Core team.",
@@ -411,11 +419,6 @@
     "name": "templating",
     "color": "fef2c0",
     "description": "Issue related to WooCommerce templates."
-  },
-  {
-    "name": "unit test",
-    "color": "ee7b30",
-    "description": "Issue related to unit tests or PRs that contain the changes for which unit tests need to be added."
   },
   {
     "name": "votes needed",

--- a/repositories.json
+++ b/repositories.json
@@ -1,4 +1,5 @@
 [
+  "woocommerce/action-scheduler",
   "woocommerce/woocommerce",
   "woocommerce/woocommerce-rest-api"
 ]


### PR DESCRIPTION
This PR adds the following:

- Adds Action Scheduler (AS) repository to sync labels to since our team is now responsible for triaging AS issues
- Adds a few new labels since they are a part of AS repo and it is a good idea to keep them
- Adds aliases for AS repo labels for which we have equivalents in our labels collection
- Adds `regression` label