### PR TITLE
Add `wc rest api` label.

### DIFF
--- a/labels/commons.json
+++ b/labels/commons.json
@@ -431,6 +431,11 @@
     "description": "Issues related to communication with woocommerce.com."
   },
   {
+    "name": "wc rest api",
+    "color": "1ccad8",
+    "description": "Issues related to WooCommerce REST API."
+  },
+  {
     "name": "won't fix",
     "color": "f5f5f5",
     "description": "Issue that will not be fixed at this time.",


### PR DESCRIPTION
**Changes in the PR:**

This PR adds `wc rest api` label in order to identify issues related to WC REST API. This label is now needed as WC REST API repo is being merged to WC Core. 