### PR TITLE
Add `support request` & `status: needs developer feedback` labels. Remove WC REST API repo from syncing. 

### DIFF
--- a/labels/commons.json
+++ b/labels/commons.json
@@ -365,7 +365,7 @@
   {
     "name": "status: needs developer feedback",
     "color": "04e824",
-    "description": "Issues that need feedback of one of the WooCommerce Core developers."
+    "description": "Issues that need feedback from one of the WooCommerce Core developers."
   },
   {
     "name": "status: needs docs",

--- a/labels/commons.json
+++ b/labels/commons.json
@@ -363,6 +363,11 @@
     "description": "Mark all PRs that have not had their changelog entries added. [auto]"
   },
   {
+    "name": "status: needs developer feedback",
+    "color": "04e824",
+    "description": "Issues that need feedback of one of the WooCommerce Core developers."
+  },
+  {
     "name": "status: needs docs",
     "color": "9cfcda",
     "description": "Needs explanation in release notes, dev blog, or documentation.",
@@ -405,6 +410,11 @@
     "aliases": [
       "Unit Tests"
     ]
+  },
+  {
+    "name": "support request",
+    "color": "ba2c73",
+    "description": "Issues submitted that are not bugs or enhancements but support requests (both dev and non-dev)."
   },
   {
     "name": "task",

--- a/repositories.json
+++ b/repositories.json
@@ -1,5 +1,4 @@
 [
   "woocommerce/action-scheduler",
-  "woocommerce/woocommerce",
-  "woocommerce/woocommerce-rest-api"
+  "woocommerce/woocommerce"
 ]


### PR DESCRIPTION
This PR includes the following:

1) Adds new label: `status: needs developer feedback`:
- Description: `Issues that need feedback from one of the WooCommerce Core developers.`
- Color: `#04e824`

2) Adds new label: `support request`:
- Description: `Issues submitted that are not bugs or enhancements but support requests (both dev and non-dev).`
- Color: `#ba2c73`

3) Removes WC REST API repository from the list of repositories where the labels should be synced since WC REST API is now a part of WooCommerce Core repository. 


