### PR TITLE
Add `tools` and 4 types of `package` labels. Remove `status: needs review` label. 

### DIFF
--- a/labels/commons.json
+++ b/labels/commons.json
@@ -271,6 +271,26 @@
     ]
   },
   {
+    "name": "package: api",
+    "color": "ea3788",
+    "description": "Issues related to @woocommerce/api package."
+  },
+  {
+    "name": "package: e2e-core-tests",
+    "color": "ea3788",
+    "description": "Issues related to @woocommerce/e2e-core-tests package."
+  },
+  {
+    "name": "package: e2e-environment",
+    "color": "ea3788",
+    "description": "Issues related to @woocommerce/e2e-environment package."
+  },
+  {
+    "name": "package: e2e-utils",
+    "color": "ea3788",
+    "description": "Issues related to @woocommerce/e2e-utils package."
+  },
+  {
     "name": "priority: critical",
     "color": "533582",
     "description": "The plugin or the store are unusable, it affects a significant number of customers."
@@ -429,6 +449,11 @@
     "name": "templating",
     "color": "fef2c0",
     "description": "Issue related to WooCommerce templates."
+  },
+  {
+    "name": "tools",
+    "color": "b0228c",
+    "description": "To-Do item for WooCommerce Tools team."
   },
   {
     "name": "votes needed",

--- a/labels/commons.json
+++ b/labels/commons.json
@@ -406,14 +406,6 @@
     ]
   },
   {
-    "name": "status: needs review",
-    "color": "1d76db",
-    "description": "PR that needs review. [auto]",
-    "aliases": [
-      "Status: Needs Review"
-    ]
-  },
-  {
     "name": "status: needs testing instructions",
     "color": "327e91",
     "description": "PRs that have not had testing instructions added to the wiki. [auto]"


### PR DESCRIPTION
This PR contains the following changes:

1) Adds the following labels for the use of the WooCommerce Tools team:
  - `tools`: `#b0228c`
  - `package: api`: `#ea3788`
  -  `package: e2e-core-tests`: `#ea3788`
  - `package: e2e-environment`: `#ea3788`
  - `package: e2e-utils`: `#ea3788`

2) Removes the following label as it is redundant:
  - `status: needs review`
