### PR TITLE
Update color of `package` labels and resolve the conflict between `needs docs` and `question` labels

### DIFF
--- a/labels/commons.json
+++ b/labels/commons.json
@@ -272,22 +272,22 @@
   },
   {
     "name": "package: api",
-    "color": "ea3788",
+    "color": "dd3388",
     "description": "Issues related to @woocommerce/api package."
   },
   {
     "name": "package: e2e-core-tests",
-    "color": "ea3788",
+    "color": "dd3388",
     "description": "Issues related to @woocommerce/e2e-core-tests package."
   },
   {
     "name": "package: e2e-environment",
-    "color": "ea3788",
+    "color": "dd3388",
     "description": "Issues related to @woocommerce/e2e-environment package."
   },
   {
     "name": "package: e2e-utils",
-    "color": "ea3788",
+    "color": "dd3388",
     "description": "Issues related to @woocommerce/e2e-utils package."
   },
   {

--- a/labels/commons.json
+++ b/labels/commons.json
@@ -392,8 +392,7 @@
     "color": "9cfcda",
     "description": "Needs explanation in release notes, dev blog, or documentation.",
     "aliases": [
-      "status: Docs",
-      "question"
+      "status: Docs"
     ]
   },
   {

--- a/labels/commons.json
+++ b/labels/commons.json
@@ -322,14 +322,6 @@
     "description": "PR that demonstrates some concept (not intended to be merged)."
   },
   {
-    "name": "question",
-    "color": "ff69b4",
-    "description": "Issue pending decision (not for support requests).",
-    "aliases": [
-      "type: question"
-    ]
-  },
-  {
     "name": "refactor",
     "color": "f9d0c4",
     "description": "Code needs refactoring."
@@ -386,6 +378,15 @@
     "name": "status: needs developer feedback",
     "color": "04e824",
     "description": "Issues that need feedback from one of the WooCommerce Core developers."
+  },
+  {
+    "name": "status: needs discussion",
+    "color": "04e824",
+    "description": "Issue that either needs discussion or pending decision (not for support requests).",
+    "aliases": [
+      "type: question",
+      "question"
+    ]
   },
   {
     "name": "status: needs docs",


### PR DESCRIPTION
This PR contains the following changes:

1) Update the color of the `package` type of labels from `#ea3788` to `#dd3388`: with `#ea3788` the text of the label is black which makes it difficult to read. With `#dd3388` the color of the label text is white which is easier to read. 
2) Remove alias `question` from `status: needs docs` label to avoid conflict (currently, if we keep things as is and run the script, labels `question` and `status: needs docs` replace each other).
3) Remove `question` and add `status: needs discussion` label instead - this is to make it more clear what the label `question` is used for. 