### PR TITLE
Update colors of `package`, `needs discussion` and `needs dev feedback` labels

### DIFF
--- a/labels/commons.json
+++ b/labels/commons.json
@@ -272,22 +272,22 @@
   },
   {
     "name": "package: api",
-    "color": "dd3388",
+    "color": "db1c8e",
     "description": "Issues related to @woocommerce/api package."
   },
   {
     "name": "package: e2e-core-tests",
-    "color": "dd3388",
+    "color": "db1c8e",
     "description": "Issues related to @woocommerce/e2e-core-tests package."
   },
   {
     "name": "package: e2e-environment",
-    "color": "dd3388",
+    "color": "db1c8e",
     "description": "Issues related to @woocommerce/e2e-environment package."
   },
   {
     "name": "package: e2e-utils",
-    "color": "dd3388",
+    "color": "db1c8e",
     "description": "Issues related to @woocommerce/e2e-utils package."
   },
   {
@@ -376,12 +376,12 @@
   },
   {
     "name": "status: needs developer feedback",
-    "color": "04e824",
+    "color": "34ad0f",
     "description": "Issues that need feedback from one of the WooCommerce Core developers."
   },
   {
     "name": "status: needs discussion",
-    "color": "04e824",
+    "color": "126dbc",
     "description": "Issue that either needs discussion or pending decision (not for support requests).",
     "aliases": [
       "type: question",


### PR DESCRIPTION
This PR contains the following changes:

- Update the color of `package` set of labels from `#dd3388` to `#db1c8e` to make it easier to read
- Update the color of `status: needs developer feedback` label from `#04e824` to `#34ad0f` to make it easier to read
- Update the color of `status: needs discussion` set of labels from `#04e824` to `#126dbc` to make it easier to read