### PR TITLE
add support for syncing to specific repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For more details about GitHub acess tokens, check ["Creating a personal access t
 |---------------------|------------------------------------------------------------|
 | `--dry-run`         | Test mode, no changes will happens in any repository       |
 | `--preserve-labels` | New labels introduced directly in GitHub will be preserved |
-| `--repo`            | Sync to this repository. Multiple repositories supported.
+| `--repo`            | Sync to this repository. Multiple repositories supported.    |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ For more details about GitHub acess tokens, check ["Creating a personal access t
 |---------------------|------------------------------------------------------------|
 | `--dry-run`         | Test mode, no changes will happens in any repository       |
 | `--preserve-labels` | New labels introduced directly in GitHub will be preserved |
+| `--repo`            | Sync to this repository. Multiple repositories supported.
 
 ## Examples
 
@@ -39,10 +40,16 @@ For more details about GitHub acess tokens, check ["Creating a personal access t
 npm start
 ```
 
-**Test mode (already runs with `--dry-run`)**
+**Test mode (already runs with `--dry-run`):**
 
 ```bash
 npm test
+```
+
+**With Options:**
+
+```bash
+npm start -- --dry-run --preserve-labels --repo organization/repository1 --repo organization/repository2
 ```
 
 ## Changelog

--- a/index.js
+++ b/index.js
@@ -1,28 +1,48 @@
 const githubLabelSync = require('github-label-sync');
 const fs = require('fs');
-const hasFlag = require('has-flag');
-const filendir = require('filendir')
+const filendir = require('filendir');
+const commandLineArgs = require('command-line-args');
+
+// Define possible command line options.
+const cmdLineOptions = [
+  {
+    name: 'dry-run',
+    type: Boolean
+  },
+  {
+    name: 'preserve-labels',
+    type: Boolean
+  },
+  {
+    name: 'repo',
+    type: String,
+    multiple: true
+  }
+];
 
 // Load config, repositories list and common labels.
+const cmdOptions = commandLineArgs( cmdLineOptions );
 const config = JSON.parse(fs.readFileSync('./config.json', 'utf8'));
-const repositories = JSON.parse(fs.readFileSync('./repositories.json', 'utf8'));
+const repositories = cmdOptions.repo || JSON.parse(fs.readFileSync('./repositories.json', 'utf8'));
 const commonLabels = JSON.parse(fs.readFileSync('./labels/commons.json', 'utf8'));
 
 // Set command line args.
-let dryRun = hasFlag('--dry-run');
-let preserveLabels = hasFlag('--preserve-labels');
+let dryRun = cmdOptions['dry-run'] || false;
+let preserveLabels = cmdOptions['preserve-labels'] || false;
 
 // Start dialog.
-console.log('Starting sync...');
+console.log('\nStarting sync...');
 if (dryRun) {
-  console.log('✔️ "--dry-run" is enabled. No changes will happens in any repository.');
+  console.log('✔️ "--dry-run" is enabled. No changes will happen in any repository.');
 }
 if (preserveLabels) {
   console.log('✔️ "--preserve-labels" is enabled. New labels introduced directly in GitHub will be preserved.');
 }
 
+console.log( '\nRepositories:' );
 // Run labels sync for each repository.
 repositories.forEach(function(repo) {
+  console.log( '  -' + repo );
   const projectLabels = './labels/' + repo + '.json';
   let labels = commonLabels;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+    },
     "array-uniq": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
@@ -200,6 +205,17 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "command-line-args": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "requires": {
+        "array-back": "^3.0.1",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      }
+    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -296,6 +312,14 @@
       "integrity": "sha512-FHZ/aVVvgxKCsDkFlSaaqduJxTR/VT/xiKtdTiF2gG6+i261nBLO5f0Gmc5R5peg+0fl+L7xvNKcs9j6KSKrzA==",
       "requires": {
         "mkdirp": "^1.0.4"
+      }
+    },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "requires": {
+        "array-back": "^3.0.1"
       }
     },
     "forever-agent": {
@@ -484,6 +508,11 @@
       "requires": {
         "json-buffer": "3.0.1"
       }
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lowercase-keys": {
       "version": "2.0.0",
@@ -698,6 +727,11 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "author": "Automattic",
   "license": "GPL-3.0+",
   "dependencies": {
+    "command-line-args": "^5.1.1",
     "filendir": "2.0.0",
-    "github-label-sync": "2.0.0",
-    "has-flag": "4.0.0"
+    "github-label-sync": "2.0.0"
   }
 }


### PR DESCRIPTION
This PR adds 

- support for specifying syncing to one or more specific repos via the command line
- spacing to the terminal output 
- lists the repos as they are processed to aid in troubleshooting when an error occurs

### Testing

- Run the command against an approved or test repo (could be created under a personal account)
```
npm start -- --dry-run --repo organization/repository1
```