### PR TITLE
Change the description of the `tools` label

### DIFF
--- a/labels/commons.json
+++ b/labels/commons.json
@@ -445,7 +445,7 @@
   {
     "name": "tools",
     "color": "b0228c",
-    "description": "To-Do item for WooCommerce Tools team."
+    "description": "GitHub action or other similar internal tooling-style item."
   },
   {
     "name": "votes needed",


### PR DESCRIPTION
Change the description of the `tools` label to: 

> GitHub action or other similar internal tooling-style item.

from the original

> To-Do item for WooCommerce Tools team.

The new description is more descriptive of what the label is about.
